### PR TITLE
Fix JSON serialization error by converting sets to lists in CustomJSONEncoder

### DIFF
--- a/apk-components-inspector.py
+++ b/apk-components-inspector.py
@@ -25,6 +25,14 @@ class IntentExtra:
     required: bool = False
     default_value: Optional[str] = None
 
+    def to_dict(self):
+        return {
+            "name": self.name,
+            "type": self.type,
+            "required": self.required,
+            "default_value": self.default_value,
+        }
+
 class SmaliAnalyzer:
     def __init__(self, decompiled_dir: str, verbose: bool = False, quiet: bool = False):
         self.decompiled_dir = Path(decompiled_dir)
@@ -1287,7 +1295,15 @@ class APKAnalyzer:
 
     def save_results(self, results: Dict[str, Any], output_path: str):
         """Save results to JSON file"""
-        Path(output_path).write_text(json.dumps(results, indent=2))
+        class CustomJSONEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, set):
+                    return list(obj)  # Convert set to list for JSON serialization
+                if isinstance(obj, IntentExtra):
+                    return obj.to_dict()
+                return super().default(obj)
+
+        Path(output_path).write_text(json.dumps(results, indent=2, cls=CustomJSONEncoder))
         if not self.quiet:
             console.print(f"\n[green]✓ Results saved to:[/] {output_path}")
 


### PR DESCRIPTION
This pull request fixes a TypeError: Object of type set is not JSON serializable
The error happens beacuse to serialize 'set' objects, which are not supported by the 'json' module.
This pull converts 'set' objects to <---> 'list'  for serialization
and also in the class IntentExtra a function added 'to_dict'  to fix the AttributeError: 'IntentExtra' object has no attribute 'to_dict'
